### PR TITLE
Update config.h

### DIFF
--- a/config.h
+++ b/config.h
@@ -6,7 +6,7 @@ public:
   int8_t thresOffset;
 };
 
-const uint8_t MPR_PADNUMS[] = {8, 9, 9, 8};
+const uint8_t MPR_PADNUMS[] = {12, 12, 12, 12};
 const uint8_t THREASHOLD = 35;
 
 touchblock touchmap[34] = {


### PR DESCRIPTION
修改MPR_PADNUMS，使传感器的12个针脚全部可用，而不是仅开启前8(9)个针脚，导致修改config.h中的区块对应针脚号失去意义